### PR TITLE
Adds ability to change the gazebo hardware_interface

### DIFF
--- a/franka_description/robots/dual_panda_example.urdf.xacro
+++ b/franka_description/robots/dual_panda_example.urdf.xacro
@@ -26,11 +26,11 @@
   </link>
 
   <!-- right arm with gripper -->
-  <xacro:panda_arm arm_id="$(arg arm_id_1)" connected_to="base"  xyz="0 -0.5 1" safety_distance="0.03"/>
+  <xacro:panda_arm arm_id="$(arg arm_id_1)" connected_to="base" xyz="0 -0.5 1" safety_distance="0.03"/>
   <xacro:hand ns="$(arg arm_id_1)" rpy="0 0 ${-pi/4}" connected_to="$(arg arm_id_1)_link8" safety_distance="0.03"/>
 
   <!-- left arm with gripper -->
-  <xacro:panda_arm arm_id="$(arg arm_id_2)" connected_to="base"  xyz="0 0.5 1" safety_distance="0.03"/>
+  <xacro:panda_arm arm_id="$(arg arm_id_2)" connected_to="base" xyz="0 0.5 1" safety_distance="0.03"/>
   <xacro:hand ns="$(arg arm_id_2)" rpy="0 0 ${-pi/4}" connected_to="$(arg arm_id_2)_link8" safety_distance="0.03"/>
 
 </robot>

--- a/franka_description/robots/hand.urdf.xacro
+++ b/franka_description/robots/hand.urdf.xacro
@@ -2,18 +2,18 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="hand">
   <xacro:arg name="use_cylinder_collision_model" default="true"/>
   <xacro:arg name="use_gazebo_sim" default="false"/>
+  <xacro:arg name="hardware_interface" default="PositionJointInterface"/>
 
-  <xacro:include filename="hand.xacro"/>
+  <xacro:include filename="$(find franka_description)/robots/hand.xacro"/>
 
   <xacro:if value="$(arg use_gazebo_sim)">
     <xacro:include filename="$(find franka_description)/robots/panda.gazebo.xacro"/>
     <xacro:include filename="$(find franka_description)/robots/panda.control.xacro"/>
   </xacro:if>
-  <xacro:hand ns="panda" rpy="0 0 ${-pi/4}" connected_to="panda_link8" safety_distance="0.03"
-    use_cylinder_collision_model="$(arg use_cylinder_collision_model)"/>
+  <xacro:hand ns="panda" rpy="0 0 ${-pi/4}" connected_to="panda_link8" safety_distance="0.03" use_cylinder_collision_model="$(arg use_cylinder_collision_model)"/>
 
   <xacro:if value="$(arg use_gazebo_sim)">
     <xacro:hand_gazebo arm_id="$(arg arm_id)"/>
-    <xacro:hand_control arm_id="$(arg arm_id)"/>
+    <xacro:hand_control arm_id="$(arg arm_id)" hardware_interface="$(arg hardware_interface)"/>
   </xacro:if>
 </robot>

--- a/franka_description/robots/hand.xacro
+++ b/franka_description/robots/hand.xacro
@@ -2,8 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="hand">
   <xacro:arg name="use_gazebo_sim" default="false"/>
   <!-- safety_distance: Minimum safety distance in [m] by which the collision volumes are expanded and which is enforced during robot motions -->
-  <xacro:macro name="hand" params="connected_to:='' ns:='' rpy:='0 0 0' xyz:='0 0 0' safety_distance:=0 
-    use_cylinder_collision_model:='true'">
+  <xacro:macro name="hand" params="connected_to:='' ns:='' rpy:='0 0 0' xyz:='0 0 0' safety_distance:=0 use_cylinder_collision_model:='true'">
     <xacro:unless value="${connected_to == ''}">
       <joint name="${ns}_hand_joint" type="fixed">
         <parent link="${connected_to}"/>
@@ -27,13 +26,13 @@
         <collision>
           <origin xyz="0 -0.05 0.04" rpy="0 0 0"/>
           <geometry>
-            <sphere radius="${0.04+safety_distance}"  />
+            <sphere radius="${0.04+safety_distance}" />
           </geometry>
         </collision>
         <collision>
           <origin xyz="0 0.05 0.04" rpy="0 0 0"/>
           <geometry>
-            <sphere radius="${0.04+safety_distance}"  />
+            <sphere radius="${0.04+safety_distance}" />
           </geometry>
         </collision>
         <collision>
@@ -45,13 +44,13 @@
         <collision>
           <origin xyz="0 -0.05 0.1" rpy="0 0 0"/>
           <geometry>
-            <sphere radius="${0.02+safety_distance}"  />
+            <sphere radius="${0.02+safety_distance}" />
           </geometry>
         </collision>
         <collision>
           <origin xyz="0 0.05 0.1" rpy="0 0 0"/>
           <geometry>
-            <sphere radius="${0.02+safety_distance}"  />
+            <sphere radius="${0.02+safety_distance}" />
           </geometry>
         </collision>
       </xacro:if>
@@ -113,7 +112,7 @@
           <inertia ixx="0.1" ixy="0.0" ixz="0.0" iyy="0.1" iyz="0.0" izz="0.1" />
         </inertial>
       </xacro:if>
-   </link>
+    </link>
     <joint name="${ns}_finger_joint1" type="prismatic">
       <parent link="${ns}_hand"/>
       <child link="${ns}_leftfinger"/>

--- a/franka_description/robots/panda.control.xacro
+++ b/franka_description/robots/panda.control.xacro
@@ -1,28 +1,28 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-    <xacro:macro name="joint_control" params="transmission joint motor">
+    <xacro:macro name="joint_control" params="transmission joint motor hardware_interface:='PositionJointInterface'">
         <transmission name="${transmission}">
             <type>transmission_interface/SimpleTransmission</type>
             <joint name="${joint}">
-                <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+                <hardwareInterface>hardware_interface/${hardware_interface}</hardwareInterface>
             </joint>
             <actuator name="${motor}">
-                <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+                <hardwareInterface>hardware_interface/${hardware_interface}</hardwareInterface>
                 <mechanicalReduction>1</mechanicalReduction>
             </actuator>
         </transmission>
     </xacro:macro>
-    <xacro:macro name="arm_control" params="arm_id">
-        <xacro:joint_control transmission="${arm_id}_tran_1" joint="${arm_id}_joint1" motor="${arm_id}_motor_1"/>
-        <xacro:joint_control transmission="${arm_id}_tran_2" joint="${arm_id}_joint2" motor="${arm_id}_motor_2"/>
-        <xacro:joint_control transmission="${arm_id}_tran_3" joint="${arm_id}_joint3" motor="${arm_id}_motor_3"/>
-        <xacro:joint_control transmission="${arm_id}_tran_4" joint="${arm_id}_joint4" motor="${arm_id}_motor_4"/>
-        <xacro:joint_control transmission="${arm_id}_tran_5" joint="${arm_id}_joint5" motor="${arm_id}_motor_5"/>
-        <xacro:joint_control transmission="${arm_id}_tran_6" joint="${arm_id}_joint6" motor="${arm_id}_motor_6"/>
-        <xacro:joint_control transmission="${arm_id}_tran_7" joint="${arm_id}_joint7" motor="${arm_id}_motor_7"/>
+    <xacro:macro name="arm_control" params="arm_id hardware_interface='PositionJointInterface'">
+        <xacro:joint_control transmission="${arm_id}_tran_1" joint="${arm_id}_joint1" motor="${arm_id}_motor_1" hardware_interface="${hardware_interface}"/>
+        <xacro:joint_control transmission="${arm_id}_tran_2" joint="${arm_id}_joint2" motor="${arm_id}_motor_2" hardware_interface="${hardware_interface}"/>
+        <xacro:joint_control transmission="${arm_id}_tran_3" joint="${arm_id}_joint3" motor="${arm_id}_motor_3" hardware_interface="${hardware_interface}"/>
+        <xacro:joint_control transmission="${arm_id}_tran_4" joint="${arm_id}_joint4" motor="${arm_id}_motor_4" hardware_interface="${hardware_interface}"/>
+        <xacro:joint_control transmission="${arm_id}_tran_5" joint="${arm_id}_joint5" motor="${arm_id}_motor_5" hardware_interface="${hardware_interface}"/>
+        <xacro:joint_control transmission="${arm_id}_tran_6" joint="${arm_id}_joint6" motor="${arm_id}_motor_6" hardware_interface="${hardware_interface}"/>
+        <xacro:joint_control transmission="${arm_id}_tran_7" joint="${arm_id}_joint7" motor="${arm_id}_motor_7" hardware_interface="${hardware_interface}"/>
     </xacro:macro>
-    <xacro:macro name="hand_control" params="arm_id">
-        <xacro:joint_control transmission="${arm_id}_leftfinger" joint="${arm_id}_finger_joint1" motor="${arm_id}_finger_joint1"/>
-        <xacro:joint_control transmission="${arm_id}_rightfinger" joint="${arm_id}_finger_joint2" motor="${arm_id}_finger_joint2"/>
+    <xacro:macro name="hand_control" params="arm_id hardware_interface='PositionJointInterface'">
+        <xacro:joint_control transmission="${arm_id}_leftfinger" joint="${arm_id}_finger_joint1" motor="${arm_id}_finger_joint1" hardware_interface="${hardware_interface}"/>
+        <xacro:joint_control transmission="${arm_id}_rightfinger" joint="${arm_id}_finger_joint2" motor="${arm_id}_finger_joint2" hardware_interface="${hardware_interface}"/>
     </xacro:macro>
 </robot>

--- a/franka_description/robots/panda_arm.urdf.xacro
+++ b/franka_description/robots/panda_arm.urdf.xacro
@@ -1,8 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="panda">
   <xacro:arg name="arm_id" default="panda"/>
   <xacro:arg name="use_cylinder_collision_model" default="true"/>
   <xacro:arg name="use_gazebo_sim" default="false"/>
+  <xacro:arg name="hardware_interface" default="PositionJointInterface"/>
 
   <xacro:include filename="$(find franka_description)/robots/panda_arm.xacro" />
 
@@ -11,14 +12,13 @@
     <xacro:include filename="$(find franka_description)/robots/panda.control.xacro"/>
   </xacro:if>
   <link name="world"/>
-  <xacro:panda_arm xyz="0 0 0" rpy="0 0 0" connected_to="world" arm_id="$(arg arm_id)"
-    safety_distance="0.03" use_cylinder_collision_model="$(arg use_cylinder_collision_model)"/>
+  <xacro:panda_arm xyz="0 0 0" rpy="0 0 0" connected_to="world" arm_id="$(arg arm_id)" safety_distance="0.03" use_cylinder_collision_model="$(arg use_cylinder_collision_model)"/>
 
   <xacro:if value="$(arg use_gazebo_sim)">
     <xacro:arm_gazebo arm_id="$(arg arm_id)"/>
-    <xacro:arm_control arm_id="$(arg arm_id)"/>
+    <xacro:arm_control arm_id="$(arg arm_id)" hardware_interface="$(arg hardware_interface)"/>
     <gazebo>
-        <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so"/>
+      <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so"/>
     </gazebo>
   </xacro:if>
 </robot>

--- a/franka_description/robots/panda_arm.xacro
+++ b/franka_description/robots/panda_arm.xacro
@@ -1,10 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="panda">
   <xacro:arg name="use_gazebo_sim" default="false"/>
   <!-- safety_distance: Minimum safety distance in [m] by which the collision volumes are expanded and which is enforced during robot motions -->
   <!-- arm_id: Namespace of the panda arm. Serves to differentiate between arms in case of multiple instances. -->
-  <xacro:macro name="panda_arm" params="arm_id:='panda' description_pkg:='franka_description'
-    connected_to:='' xyz:='0 0 0' rpy:='0 0 0' safety_distance:=0 use_cylinder_collision_model:='true'">
+  <xacro:macro name="panda_arm" params="arm_id:='panda' description_pkg:='franka_description' connected_to:='' xyz:='0 0 0' rpy:='0 0 0' safety_distance:=0 use_cylinder_collision_model:='true'">
     <xacro:unless value="${not connected_to}">
       <joint name="${arm_id}_virtual_joint" type="fixed">
         <parent link="${connected_to}"/>
@@ -51,8 +50,7 @@
                             parent_link child_link limit_effort:='' limit_lower:='' limit_upper:='' limit_velocity:=''">
       <joint name="${name}" type="${type}">
         <xacro:if value="${type == 'revolute'}">
-          <safety_controller k_position="100.0" k_velocity="40.0"
-            soft_lower_limit="${soft_lower_limit}" soft_upper_limit="${soft_upper_limit}"/>
+          <safety_controller k_position="100.0" k_velocity="40.0" soft_lower_limit="${soft_lower_limit}" soft_upper_limit="${soft_upper_limit}"/>
         </xacro:if>
         <origin rpy="${rpy}" xyz="${xyz}"/>
         <parent link="${parent_link}"/>
@@ -252,13 +250,13 @@
           <collision>
             <origin xyz="0 0 0.08" rpy="0 0 0"/>
             <geometry>
-              <sphere radius="${0.04+safety_distance}"  />
+              <sphere radius="${0.04+safety_distance}" />
             </geometry>
           </collision>
           <collision>
             <origin xyz="0 0 -0.06" rpy="0 0 0"/>
             <geometry>
-              <sphere radius="${0.04+safety_distance}"  />
+              <sphere radius="${0.04+safety_distance}" />
             </geometry>
           </collision>
         </cylinder_collision_model>
@@ -268,19 +266,19 @@
           <collision>
             <origin xyz="0.0424 0.0424 -0.0250" rpy="${pi} ${pi/2} ${pi/2}"/>
             <geometry>
-              <cylinder radius="${0.03+safety_distance}"  length="0.01" />
+              <cylinder radius="${0.03+safety_distance}" length="0.01" />
             </geometry>
           </collision>
           <collision>
             <origin xyz="0.0424 0.0424 -0.02" rpy="0 0 0"/>
             <geometry>
-              <sphere radius="${0.03+safety_distance}"  />
+              <sphere radius="${0.03+safety_distance}" />
             </geometry>
           </collision>
           <collision>
             <origin xyz="0.0424 0.0424 -0.03" rpy="0 0 0"/>
             <geometry>
-              <sphere radius="${0.03+safety_distance}"  />
+              <sphere radius="${0.03+safety_distance}" />
             </geometry>
           </collision>
         </cylinder_collision_model>
@@ -288,44 +286,28 @@
     </xacro:if>
     <!-- Empty content must be passed for cylinder_collision_model as block parameters cannot be defaulted-->
     <xacro:unless value="${use_cylinder_collision_model}">
-      <xacro:arm_link name="${arm_id}_link0" visual_mesh="package://${description_pkg}/meshes/visual/link0.dae"
-        collision_mesh="package://${description_pkg}/meshes/collision/link0.stl" mass="3.06"
-        use_cylinder_collision_model="false">
+      <xacro:arm_link name="${arm_id}_link0" visual_mesh="package://${description_pkg}/meshes/visual/link0.dae" collision_mesh="package://${description_pkg}/meshes/collision/link0.stl" mass="3.06" use_cylinder_collision_model="false">
         <cylinder_collision_model></cylinder_collision_model>
       </xacro:arm_link>
-      <xacro:arm_link name="${arm_id}_link1" visual_mesh="package://${description_pkg}/meshes/visual/link1.dae"
-        collision_mesh="package://${description_pkg}/meshes/collision/link1.stl" mass="2.34"
-        use_cylinder_collision_model="false">
+      <xacro:arm_link name="${arm_id}_link1" visual_mesh="package://${description_pkg}/meshes/visual/link1.dae" collision_mesh="package://${description_pkg}/meshes/collision/link1.stl" mass="2.34" use_cylinder_collision_model="false">
         <cylinder_collision_model></cylinder_collision_model>
       </xacro:arm_link>
-      <xacro:arm_link name="${arm_id}_link2" visual_mesh="package://${description_pkg}/meshes/visual/link2.dae"
-        collision_mesh="package://${description_pkg}/meshes/collision/link2.stl" mass="2.36"
-        use_cylinder_collision_model="false">
+      <xacro:arm_link name="${arm_id}_link2" visual_mesh="package://${description_pkg}/meshes/visual/link2.dae" collision_mesh="package://${description_pkg}/meshes/collision/link2.stl" mass="2.36" use_cylinder_collision_model="false">
         <cylinder_collision_model></cylinder_collision_model>
       </xacro:arm_link>
-      <xacro:arm_link name="${arm_id}_link3" visual_mesh="package://${description_pkg}/meshes/visual/link3.dae"
-        collision_mesh="package://${description_pkg}/meshes/collision/link3.stl" mass="2.38"
-        use_cylinder_collision_model="false">
+      <xacro:arm_link name="${arm_id}_link3" visual_mesh="package://${description_pkg}/meshes/visual/link3.dae" collision_mesh="package://${description_pkg}/meshes/collision/link3.stl" mass="2.38" use_cylinder_collision_model="false">
         <cylinder_collision_model></cylinder_collision_model>
       </xacro:arm_link>
-      <xacro:arm_link name="${arm_id}_link4" visual_mesh="package://${description_pkg}/meshes/visual/link4.dae"
-        collision_mesh="package://${description_pkg}/meshes/collision/link4.stl" mass="2.43"
-        use_cylinder_collision_model="false">
+      <xacro:arm_link name="${arm_id}_link4" visual_mesh="package://${description_pkg}/meshes/visual/link4.dae" collision_mesh="package://${description_pkg}/meshes/collision/link4.stl" mass="2.43" use_cylinder_collision_model="false">
         <cylinder_collision_model></cylinder_collision_model>
       </xacro:arm_link>
-      <xacro:arm_link name="${arm_id}_link5" visual_mesh="package://${description_pkg}/meshes/visual/link5.dae"
-        collision_mesh="package://${description_pkg}/meshes/collision/link5.stl" mass="3.5"
-        use_cylinder_collision_model="false">
+      <xacro:arm_link name="${arm_id}_link5" visual_mesh="package://${description_pkg}/meshes/visual/link5.dae" collision_mesh="package://${description_pkg}/meshes/collision/link5.stl" mass="3.5" use_cylinder_collision_model="false">
         <cylinder_collision_model></cylinder_collision_model>
       </xacro:arm_link>
-      <xacro:arm_link name="${arm_id}_link6" visual_mesh="package://${description_pkg}/meshes/visual/link6.dae"
-        collision_mesh="package://${description_pkg}/meshes/collision/link6.stl" mass="1.47"
-        use_cylinder_collision_model="false">
+      <xacro:arm_link name="${arm_id}_link6" visual_mesh="package://${description_pkg}/meshes/visual/link6.dae" collision_mesh="package://${description_pkg}/meshes/collision/link6.stl" mass="1.47" use_cylinder_collision_model="false">
         <cylinder_collision_model></cylinder_collision_model>
       </xacro:arm_link>
-      <xacro:arm_link name="${arm_id}_link7" visual_mesh="package://${description_pkg}/meshes/visual/link7.dae"
-        collision_mesh="package://${description_pkg}/meshes/collision/link7.stl" mass="0.45"
-        use_cylinder_collision_model="false">
+      <xacro:arm_link name="${arm_id}_link7" visual_mesh="package://${description_pkg}/meshes/visual/link7.dae" collision_mesh="package://${description_pkg}/meshes/collision/link7.stl" mass="0.45" use_cylinder_collision_model="false">
         <cylinder_collision_model></cylinder_collision_model>
       </xacro:arm_link>
       <xacro:arm_link name="${arm_id}_link8">
@@ -333,28 +315,13 @@
       </xacro:arm_link>
     </xacro:unless>
 
-    <xacro:arm_joint name="${arm_id}_joint1" type="revolute" soft_lower_limit="-2.8973" soft_upper_limit="2.8973"
-      rpy="0 0 0" xyz="0 0 0.333" parent_link="${arm_id}_link0" child_link="${arm_id}_link1" limit_effort="87"
-      limit_lower="-2.8973" limit_upper="2.8973" limit_velocity="2.1750"/>
-    <xacro:arm_joint name="${arm_id}_joint2" type="revolute" soft_lower_limit="-1.7628" soft_upper_limit="1.7628"
-      rpy="${-pi/2} 0 0" xyz="0 0 0" parent_link="${arm_id}_link1" child_link="${arm_id}_link2" limit_effort="87"
-      limit_lower="-1.7628" limit_upper="1.7628" limit_velocity="2.1750"/>
-    <xacro:arm_joint name="${arm_id}_joint3" type="revolute" soft_lower_limit="-2.8973" soft_upper_limit="2.8973"
-      rpy="${pi/2} 0 0" xyz="0 -0.316 0" parent_link="${arm_id}_link2" child_link="${arm_id}_link3" limit_effort="87"
-      limit_lower="-2.8973" limit_upper="2.8973" limit_velocity="2.1750"/>
-    <xacro:arm_joint name="${arm_id}_joint4" type="revolute" soft_lower_limit="-3.0718" soft_upper_limit="-0.0698"
-      rpy="${pi/2} 0 0" xyz="0.0825 0 0" parent_link="${arm_id}_link3" child_link="${arm_id}_link4" limit_effort="87"
-      limit_lower="-3.0718" limit_upper="-0.0698" limit_velocity="2.1750"/>
-    <xacro:arm_joint name="${arm_id}_joint5" type="revolute" soft_lower_limit="-2.8973" soft_upper_limit="2.8973"
-      rpy="${-pi/2} 0 0" xyz="-0.0825 0.384 0" parent_link="${arm_id}_link4" child_link="${arm_id}_link5" limit_effort="12"
-      limit_lower="-2.8973" limit_upper="2.8973" limit_velocity="2.6100"/>
-    <xacro:arm_joint name="${arm_id}_joint6" type="revolute" soft_lower_limit="-0.0175" soft_upper_limit="3.7525"
-      rpy="${pi/2} 0 0" xyz="0 0 0" parent_link="${arm_id}_link5" child_link="${arm_id}_link6" limit_effort="12"
-      limit_lower="-0.0175" limit_upper="3.7525" limit_velocity="2.6100"/>
-    <xacro:arm_joint name="${arm_id}_joint7" type="revolute" soft_lower_limit="-2.8973" soft_upper_limit="2.8973"
-      rpy="${pi/2} 0 0" xyz="0.088 0 0" parent_link="${arm_id}_link6" child_link="${arm_id}_link7" limit_effort="12"
-      limit_lower="-2.8973" limit_upper="2.8973" limit_velocity="2.6100"/>
-    <xacro:arm_joint name="${arm_id}_joint8" type="fixed" parent_link="${arm_id}_link7" child_link="${arm_id}_link8"
-      rpy="0 0 0" xyz="0 0 0.107"/>
+    <xacro:arm_joint name="${arm_id}_joint1" type="revolute" soft_lower_limit="-2.8973" soft_upper_limit="2.8973" rpy="0 0 0" xyz="0 0 0.333" parent_link="${arm_id}_link0" child_link="${arm_id}_link1" limit_effort="87" limit_lower="-2.8973" limit_upper="2.8973" limit_velocity="2.1750"/>
+    <xacro:arm_joint name="${arm_id}_joint2" type="revolute" soft_lower_limit="-1.7628" soft_upper_limit="1.7628" rpy="${-pi/2} 0 0" xyz="0 0 0" parent_link="${arm_id}_link1" child_link="${arm_id}_link2" limit_effort="87" limit_lower="-1.7628" limit_upper="1.7628" limit_velocity="2.1750"/>
+    <xacro:arm_joint name="${arm_id}_joint3" type="revolute" soft_lower_limit="-2.8973" soft_upper_limit="2.8973" rpy="${pi/2} 0 0" xyz="0 -0.316 0" parent_link="${arm_id}_link2" child_link="${arm_id}_link3" limit_effort="87" limit_lower="-2.8973" limit_upper="2.8973" limit_velocity="2.1750"/>
+    <xacro:arm_joint name="${arm_id}_joint4" type="revolute" soft_lower_limit="-3.0718" soft_upper_limit="-0.0698" rpy="${pi/2} 0 0" xyz="0.0825 0 0" parent_link="${arm_id}_link3" child_link="${arm_id}_link4" limit_effort="87" limit_lower="-3.0718" limit_upper="-0.0698" limit_velocity="2.1750"/>
+    <xacro:arm_joint name="${arm_id}_joint5" type="revolute" soft_lower_limit="-2.8973" soft_upper_limit="2.8973" rpy="${-pi/2} 0 0" xyz="-0.0825 0.384 0" parent_link="${arm_id}_link4" child_link="${arm_id}_link5" limit_effort="12" limit_lower="-2.8973" limit_upper="2.8973" limit_velocity="2.6100"/>
+    <xacro:arm_joint name="${arm_id}_joint6" type="revolute" soft_lower_limit="-0.0175" soft_upper_limit="3.7525" rpy="${pi/2} 0 0" xyz="0 0 0" parent_link="${arm_id}_link5" child_link="${arm_id}_link6" limit_effort="12" limit_lower="-0.0175" limit_upper="3.7525" limit_velocity="2.6100"/>
+    <xacro:arm_joint name="${arm_id}_joint7" type="revolute" soft_lower_limit="-2.8973" soft_upper_limit="2.8973" rpy="${pi/2} 0 0" xyz="0.088 0 0" parent_link="${arm_id}_link6" child_link="${arm_id}_link7" limit_effort="12" limit_lower="-2.8973" limit_upper="2.8973" limit_velocity="2.6100"/>
+    <xacro:arm_joint name="${arm_id}_joint8" type="fixed" parent_link="${arm_id}_link7" child_link="${arm_id}_link8" rpy="0 0 0" xyz="0 0 0.107"/>
   </xacro:macro>
 </robot>


### PR DESCRIPTION
This commit gives users the ability to change the hardware_interface that is used in the gazebo simulation. It is similar to the implementation done in the https://github.com/OrebroUniversity/yumi/blob/master/yumi_description/urdf/yumi.transmission.xacro.

@tahsinkose Feel free to decide to merge it into your pull request. Otherwise, please close this pull request, and I will create a separate pull request after your pull request has been merged.